### PR TITLE
Fix some issues regarding consistent use of variable names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ MONGO_ROOT_USERNAME=root
 MONGO_ROOT_PASSWORD=example
 
 # Public base URL for the orchestrator application.
-PUBLIC_HOST=http://orchestrator
+PUBLIC_HOST=
 PUBLIC_PORT=3000
 
 # Error tracing. Leave empty for no tracing.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,15 @@ orchestrating logic for WebAssembly-based microservices.
 - Web GUI
 
 ## Installation
-Clone the project and its submodules and use `docker compose` to build and start the server.
+Clone the project and its submodules.
+
+```bash
+git clone --recursive git@github.com:LiquidAI-project/wasmiot-orchestrator.git
+cd wasmiot-orchestrator
+```
+
+Use `docker compose` to build and start the server.
+
 
 Using Windows 10 you could do the following:
 ```powershell

--- a/docker-compose.example-devices.yml
+++ b/docker-compose.example-devices.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   # TODO Set IOT-device hostnames to end with ".local."? Considered using `domainname`
   # (see https://docs.docker.com/compose/compose-file/#domainname) but had no

--- a/docker-compose.vm.yml
+++ b/docker-compose.vm.yml
@@ -2,25 +2,26 @@ version: '3.4'
 
 services:
   orchestrator:
+    image: ghcr.io/liquidai-project/wasmiot-orchestrator
     build:
       context: ./fileserv
       dockerfile: ./Dockerfile
       target: compose
+    restart: always
     ports:
       - ${PUBLIC_PORT:-3000}:3000
     command: nodejs ./server.js
     environment:
-      CONFIG_MONGODB_HOST: ${MONGO_HOST:-mongo}
-      CONFIG_MONGODB_PORT: ${MONGO_PORT:-27017}
-      CONFIG_MONGODB_ADMINUSERNAME: ${MONGO_ROOT_USERNAME}
-      CONFIG_MONGODB_ADMINPASSWORD: ${MONGO_ROOT_PASSWORD}
-      CONFIG_PUBLIC_HOST: ${PUBLIC_HOST:-http://orchestrator}
-      CONFIG_PUBLIC_PORT: ${PUBLIC_PORT:-3000}
+      MONGO_HOST: ${MONGO_HOST:-mongo}
+      MONGO_PORT: ${MONGO_PORT:-27017}
+      MONGO_ROOT_USERNAME: ${MONGO_ROOT_USERNAME}
+      MONGO_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD}
+      PUBLIC_HOST: ${PUBLIC_HOST:-}
+      PUBLIC_PORT: ${PUBLIC_PORT:-3000}
 
   mongo:
-    image: mongo:4.4.20
-    restart: unless-stopped
-    # TODO Add volumes for db.
+    image: mongo
+    restart: always
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USERNAME}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD}
@@ -31,7 +32,7 @@ services:
 
   mdns-reflector:
     image: flungo/avahi
-    restart: unless-stopped
+    restart: always
     environment:
       REFLECTOR_ENABLE_REFLECTOR: "yes"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   orchestrator-base:
     image: ghcr.io/liquidai-project/wasmiot-orchestrator
@@ -8,23 +6,26 @@ services:
       dockerfile: ./Dockerfile
     ports:
       - ${PUBLIC_PORT:-3000}:3000
+    restart: always
     networks:
       default:
     environment:
-      MONGO_HOST: ${MONGO_ROOT_USERNAME:-mongo}
+      MONGO_HOST: ${MONGO_HOST:-mongo}
       MONGO_PORT: ${MONGO_PORT:-27017}
-      MONGO_ROOT_USERNAME: ${MONGO_ROOT_USERNAME:-root}
-      MONGO_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:-example}
+      MONGO_ROOT_USERNAME: ${MONGO_ROOT_USERNAME}
+      MONGO_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD}
+      PUBLIC_HOST: ${PUBLIC_HOST:-}
+      PUBLIC_PORT: ${PUBLIC_PORT:-3000}
     command: nodejs ./server.js
 
   mongo:
     image: mongo
-    restart: unless-stopped
+    restart: always
     networks:
       default:
     environment:
-      MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USERNAME:-root}
-      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:-example}
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD}
     command: mongod --port ${MONGO_PORT:-27017}
     volumes:
       - mongo-config:/DATA/CONFIGDB

--- a/fileserv/constants.js
+++ b/fileserv/constants.js
@@ -7,17 +7,17 @@ const path = require("path");
 
 require('dotenv').config({path: path.join(__dirname, "..", ".env"), override: true});
 
-const mongo_host = process.env.MONGODB_HOST || "mongo";
-const mongo_port = process.env.MONGODB_PORT || "27017";
-const mongo_user = process.env.MONGO_ROOT_USERNAME;
-const mongo_pass = process.env.MONGO_ROOT_PASSWORD;
-const MONGO_URI = `mongodb://${mongo_user}:${mongo_pass}@${mongo_host}:${mongo_port}/`;
+const MONGO_HOST = process.env.MONGO_HOST || "mongo";
+const MONGO_PORT = process.env.MONGO_PORT || "27017";
+const MONGO_USER = process.env.MONGO_ROOT_USERNAME;
+const MONGO_PASS = process.env.MONGO_ROOT_PASSWORD;
+const MONGO_URI = `mongodb://${MONGO_USER}:${MONGO_PASS}@${MONGO_HOST}:${MONGO_PORT}/`;
 
 const SENTRY_DSN = process.env.SENTRY_DSN;
 
-const public_host = process.env.PUBLIC_HOST || `http://${require("os").hostname()}`;
+const PUBLIC_HOST = process.env.PUBLIC_HOST || `http://${require("os").hostname()}`;
 const PUBLIC_PORT = process.env.PUBLIC_PORT || "3000";
-const PUBLIC_BASE_URI = `${public_host}:${PUBLIC_PORT}/`;
+const PUBLIC_BASE_URI = `${PUBLIC_HOST}:${PUBLIC_PORT}/`;
 
 const MODULE_DIR = path.join(__dirname, "files", "wasm");
 const EXECUTION_INPUT_DIR = path.join(__dirname, "files", "exec");


### PR DESCRIPTION
Related to issue #76 although after fresh install could not reproduce the same crash mentioned in the issue.

Fixes some inconsistent naming regarding environment variables for MongoDB connection and for the public URL of the orchestrator.

Unless it can be fully confirmed that everything works, should probably not be merged into main before the ICWE demo is finalized.