### PR TITLE
fileserv: fix deploy, execute, failover, and manifest edge cases

### DIFF
--- a/fileserv/Dockerfile
+++ b/fileserv/Dockerfile
@@ -8,8 +8,7 @@ WORKDIR /app/fileserv
 COPY package*.json ./
 
 # RUN npm install
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci
+RUN npm ci
 
 COPY . .
 

--- a/fileserv/Dockerfile-production
+++ b/fileserv/Dockerfile-production
@@ -8,8 +8,7 @@ WORKDIR /app/fileserv
 COPY package*.json ./
 
 # RUN npm install
-RUN --mount=type=cache,target=/root/.npm \
-    npm clean-install --omit=dev
+RUN npm clean-install --omit=dev
 
 COPY . .
 

--- a/fileserv/constants.js
+++ b/fileserv/constants.js
@@ -7,11 +7,43 @@ const path = require("path");
 
 require('dotenv').config({path: path.join(__dirname, "..", ".env"), override: true});
 
+const { Agent } = require("undici");
+
+/**
+ * Undici's default headersTimeout is 300s. Slow devices (Pi 2 + large WASM) can take
+ * longer to respond to POST /deploy before the first byte of the response — that
+ * yields HeadersTimeoutError (UND_ERR_HEADERS_TIMEOUT) inside the orchestrator even
+ * when the Python client uses PIPELINE_DEPLOY_TIMEOUT_PER_DEVICE=600s.
+ * Tune via ORCH_DEVICE_*_TIMEOUT_MS (milliseconds).
+ */
+const ORCH_DEVICE_HEADERS_TIMEOUT_MS = parseInt(
+    process.env.ORCH_DEVICE_HEADERS_TIMEOUT_MS || "900000",
+    10
+);
+const ORCH_DEVICE_BODY_TIMEOUT_MS = parseInt(
+    process.env.ORCH_DEVICE_BODY_TIMEOUT_MS || "900000",
+    10
+);
+const ORCH_DEVICE_CONNECT_TIMEOUT_MS = parseInt(
+    process.env.ORCH_DEVICE_CONNECT_TIMEOUT_MS || "120000",
+    10
+);
+
+/** Shared dispatcher for orchestrator -> supervisor HTTP (deploy, execute, etc.) */
+const deviceFetchAgent = new Agent({
+    headersTimeout: ORCH_DEVICE_HEADERS_TIMEOUT_MS,
+    bodyTimeout: ORCH_DEVICE_BODY_TIMEOUT_MS,
+    connectTimeout: ORCH_DEVICE_CONNECT_TIMEOUT_MS,
+});
+
 const MONGO_HOST = process.env.MONGO_HOST || "mongo";
 const MONGO_PORT = process.env.MONGO_PORT || "27017";
 const MONGO_USER = process.env.MONGO_ROOT_USERNAME;
 const MONGO_PASS = process.env.MONGO_ROOT_PASSWORD;
-const MONGO_URI = `mongodb://${MONGO_USER}:${MONGO_PASS}@${MONGO_HOST}:${MONGO_PORT}/`;
+const MONGO_URI = process.env.MONGO_URI
+    || (MONGO_USER && MONGO_PASS
+        ? `mongodb://${MONGO_USER}:${MONGO_PASS}@${MONGO_HOST}:${MONGO_PORT}/`
+        : `mongodb://${MONGO_HOST}:${MONGO_PORT}/`);
 
 const SENTRY_DSN = process.env.SENTRY_DSN;
 
@@ -25,6 +57,9 @@ const USE_WEBSOCKET = process.env.WASMIOT_USE_WEB_SOCKETS === "true";
 
 const INIT_FOLDER = process.env.WASMIOT_INIT_FOLDER || "/init";
 const CLEAR_LOGS = process.env.WASMIOT_CLEAR_LOGS === "true";
+
+// Timeout (ms) when fetching execution result from device. LOF can take ~300s on raspi2; trust scoring also slow.
+const EXECUTION_RESULT_FETCH_TIMEOUT_MS = parseInt(process.env.EXECUTION_RESULT_FETCH_TIMEOUT_MS || "300000", 10);
 
 const MODULE_DIR = path.join(__dirname, "files", "wasm");
 const EXECUTION_INPUT_DIR = path.join(__dirname, "files", "exec");
@@ -43,7 +78,8 @@ const FILE_TYPES = [
     "image/png",
     "image/jpeg",
     "image/jpg",
-    "application/octet-stream"
+    "application/octet-stream",
+    "text/csv"
 ];
 
 /**
@@ -70,7 +106,8 @@ module.exports = {
     DEVICE_DESC_ROUTE,
     DEVICE_HEALTH_ROUTE,
     DEVICE_TYPE,
-    DEVICE_HEALTHCHECK_THRESHOLD: 5,
+    // Failed health checks before marking inactive / triggering failover (was 5; 1 = faster DR tests).
+    DEVICE_HEALTHCHECK_THRESHOLD: parseInt(process.env.DEVICE_HEALTHCHECK_THRESHOLD || "1", 10),
     FRONT_END_DIR,
     DEVICE_SCAN_DURATION_MS: 5*1000,
     DEVICE_SCAN_INTERVAL_MS: 60*1000,
@@ -81,4 +118,9 @@ module.exports = {
     WASMIOT_INIT_FUNCTION_NAME,
     INIT_FOLDER,
     CLEAR_LOGS,
+    EXECUTION_RESULT_FETCH_TIMEOUT_MS,
+    ORCH_DEVICE_HEADERS_TIMEOUT_MS,
+    ORCH_DEVICE_BODY_TIMEOUT_MS,
+    ORCH_DEVICE_CONNECT_TIMEOUT_MS,
+    deviceFetchAgent,
 };

--- a/fileserv/package-lock.json
+++ b/fileserv/package-lock.json
@@ -19,6 +19,7 @@
         "mongodb": "^6.16.0",
         "multer": "^2.0.0",
         "semver": "^7.7.2",
+        "undici": "^6.24.1",
         "ws": "^8.18.2"
       },
       "devDependencies": {
@@ -6910,6 +6911,15 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -12261,6 +12271,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
+    "undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="
     },
     "undici-types": {
       "version": "5.26.5",

--- a/fileserv/package.json
+++ b/fileserv/package.json
@@ -22,6 +22,7 @@
     "mongodb": "^6.16.0",
     "multer": "^2.0.0",
     "semver": "^7.7.2",
+    "undici": "^6.24.1",
     "ws": "^8.18.2"
   },
   "devDependencies": {

--- a/fileserv/routes/deployment.js
+++ b/fileserv/routes/deployment.js
@@ -89,9 +89,11 @@ const createDeployment = async (request, response) => {
 
         console.error(errorMsg, err, err.stack);
 
+        // Surface err.message in response (Error objects serialize as {} otherwise)
+        const errDetail = err && (err.message || String(err));
         response
             .status(500)
-            .json(new utils.Error(errorMsg, err));
+            .json(new utils.Error(errorMsg, errDetail ? { message: errDetail } : err));
     }
 }
 
@@ -245,13 +247,14 @@ const updateSequence = async (request, response) => {
     try {
         deployment = await orchestrator.solve(deployment, true);
     } catch (err) {
-        errorMsg = "Failed updating manifest for deployment" + deploymentId + err;
+        const errorMsg = "Failed updating manifest for deployment" + deploymentId + err;
 
         console.error(errorMsg, err.stack);
 
         response
             .status(500)
             .json(new utils.Error(errorMsg));
+        return;
     }
 
     if (isActive) {

--- a/fileserv/routes/execution.js
+++ b/fileserv/routes/execution.js
@@ -1,9 +1,84 @@
 const { ObjectId } = require("mongodb");
 const express = require("express");
 
-const { EXECUTION_INPUT_DIR } = require("../constants.js");
+const {
+    EXECUTION_INPUT_DIR,
+    EXECUTION_RESULT_FETCH_TIMEOUT_MS,
+    deviceFetchAgent,
+} = require("../constants.js");
 const utils = require("../utils.js");
 
+/**
+ * Rewrite 127.0.0.1/localhost in a URL to the device's actual address.
+ * Supervisors return resultUrl with their own localhost, which is unreachable
+ * from the orchestrator when it runs on a different host.
+ */
+function rewriteResultUrl(url, deviceHost) {
+    if (!url || !deviceHost) return url;
+    try {
+        const parsed = new URL(url);
+        if (["127.0.0.1", "localhost", "::1"].includes(parsed.hostname)) {
+            parsed.hostname = deviceHost;
+            return parsed.toString();
+        }
+    } catch (e) {}
+    return url;
+}
+
+/**
+ * Supervisor sometimes returns result="Mount error: ..." while resultUrl points at request-history
+ * that later shows success:true (stale error string). If history says success, prefer that.
+ */
+async function tryPreferRequestHistoryWhenResultLooksLikeMountError(json, deviceHost, isInFailover) {
+    if (!json || !json.resultUrl) {
+        return null;
+    }
+    const msg = typeof json.result === "string" ? json.result : "";
+    if (!msg || (!msg.includes("Mount error") && !msg.includes("Unexpected input file"))) {
+        return null;
+    }
+    let resultUrlStr = json.resultUrl;
+    if (deviceHost) {
+        resultUrlStr = rewriteResultUrl(resultUrlStr, deviceHost);
+    }
+    try {
+        const options = { method: "GET" };
+        if (typeof AbortSignal !== "undefined" && AbortSignal.timeout) {
+            options.signal = AbortSignal.timeout(EXECUTION_RESULT_FETCH_TIMEOUT_MS);
+        }
+        if (deviceFetchAgent) {
+            options.dispatcher = deviceFetchAgent;
+        }
+        const r = await fetch(resultUrlStr, options);
+        if (!r.ok) {
+            return null;
+        }
+        const hist = await r.json();
+        if (hist && hist.success === true) {
+            let device;
+            try {
+                device = new URL(resultUrlStr).hostname;
+            } catch (e) {}
+            let resultUrlOut = resultUrlStr;
+            if (deviceHost) {
+                resultUrlOut = rewriteResultUrl(resultUrlStr, deviceHost);
+            }
+            const fetchedFrom =
+                deviceHost ||
+                (device && !["127.0.0.1", "localhost", "::1"].includes(device) ? device : null) ||
+                device;
+            return {
+                result: hist.result !== undefined ? hist.result : null,
+                fetched_from_device: fetchedFrom,
+                resultUrl: resultUrlOut,
+                isInFailover: isInFailover,
+            };
+        }
+    } catch (e) {
+        console.log("tryPreferRequestHistoryWhenResultLooksLikeMountError:", e.message);
+    }
+    return null;
+}
 
 let deploymentCollection = null
 
@@ -39,7 +114,10 @@ const execute = async (request, response) => {
 
     try {
         let args = {};
-        args.body = request.body;
+        // Merge query params into body: Python client sends params as URL query string;
+        // when body is undefined (e.g. POST with no body), schedule() would crash on
+        // "param0 in undefined". Use query as fallback so param0, param1, etc. are available.
+        args.body = Object.assign({}, request.query || {}, request.body || {});
         if (request.files) {
             args.files = request.files.map(file => ({ path: file.path, name: file.fieldname }));
         } else {
@@ -49,6 +127,16 @@ const execute = async (request, response) => {
         if (!execResponse.ok) {
             throw JSON.stringify(await execResponse.json());
         }
+        // Device host for rewriting 127.0.0.1 in resultUrl (supervisor returns its localhost)
+        let deviceHost = null;
+        try {
+            const startEndpoint = utils.getStartEndpoint(deployment);
+            if (startEndpoint && startEndpoint.url) {
+                deviceHost = startEndpoint.url.hostname;
+            }
+        } catch (e) {
+            console.log("Could not get start endpoint for resultUrl rewrite:", e.message);
+        }
         // Recursively seek the end of the execution chain in order respond with
         // the end result of all steps in the executed sequence.
         let tries = 0;
@@ -56,6 +144,7 @@ const execute = async (request, response) => {
         let statusCode = 500;
         let result = new utils.Error("undefined error");
         let redirectUrl;
+        let options;
         while (true) {
             let json;
             try {
@@ -70,9 +159,23 @@ const execute = async (request, response) => {
             if (json.result && json.status !== "error") {
                 // Check if the result is a URL to follow...
                 try {
-                    redirectUrl = new URL(json.result);
+                    let resultStr = typeof json.result === "string" ? json.result : String(json.result);
+                    if (deviceHost) resultStr = rewriteResultUrl(resultStr, deviceHost);
+                    redirectUrl = new URL(resultStr);
                     depth += 1;
                 } catch (e) {
+                    // Non-URL result string: often final output, but supervisor may send a stale
+                    // mount error while request-history for resultUrl is success — prefer history.
+                    const preferred = await tryPreferRequestHistoryWhenResultLooksLikeMountError(
+                        json,
+                        deviceHost,
+                        isInFailover
+                    );
+                    if (preferred) {
+                        result = preferred;
+                        statusCode = 200;
+                        break;
+                    }
                     // Assume this is the final result.
                     console.log("Result found!", JSON.stringify(json, null, 2));
                     let device;
@@ -82,10 +185,17 @@ const execute = async (request, response) => {
                         } catch (e) {}
                     }
 
+                    let resultUrlOut = json.resultUrl;
+                    if (deviceHost) resultUrlOut = rewriteResultUrl(resultUrlOut, deviceHost);
+                    if (!device && resultUrlOut) {
+                        try { device = new URL(resultUrlOut).hostname; } catch (e) {}
+                    }
+                    // Prefer deviceHost (actual device IP); avoid 127.0.0.1 from device URL
+                    const fetchedFrom = deviceHost || (device && !["127.0.0.1", "localhost", "::1"].includes(device) ? device : null) || device;
                     result = {
                         result: json.result,
-                        fetched_from_device: device,
-                        resultUrl: json.resultUrl,
+                        fetched_from_device: fetchedFrom,
+                        resultUrl: resultUrlOut,
                         isInFailover: isInFailover // Pass the failover-state of the deployment to the client, so that it can be displayed in the UI.
                     };
 
@@ -97,14 +207,24 @@ const execute = async (request, response) => {
                 break;
             } else if (json.resultUrl) {
                 try {
-                    redirectUrl = new URL(json.resultUrl);
+                    let resultUrlStr = json.resultUrl;
+                    if (deviceHost) resultUrlStr = rewriteResultUrl(resultUrlStr, deviceHost);
+                    redirectUrl = new URL(resultUrlStr);
                 } catch (e) {
                     console.log(`received a bad redirection-URL`, e);
                 }
                 depth += 1;
             }
 
+            if (!redirectUrl) break;
+
             options = { method: "GET" };
+            if (typeof AbortSignal !== "undefined" && AbortSignal.timeout) {
+                options.signal = AbortSignal.timeout(EXECUTION_RESULT_FETCH_TIMEOUT_MS);
+            }
+            if (deviceFetchAgent) {
+                options.dispatcher = deviceFetchAgent;
+            }
 
             console.log(`(Try ${tries}, depth ${depth}) Fetching result from: ${redirectUrl}`);
             execResponse = await fetch(redirectUrl, options);
@@ -114,7 +234,14 @@ const execute = async (request, response) => {
                 if (execResponse.status == 404 && depth < 5 && tries < 5) {
                     await new Promise(resolve => setTimeout(resolve, 5000));
                 } else {
-                    result = new utils.Error("fetching result failed: " + execResponse.statusText);
+                    let bodyHint = "";
+                    try {
+                        const txt = await execResponse.text();
+                        if (txt && txt.length < 200) bodyHint = ": " + txt;
+                    } catch (_) {}
+                    const host = redirectUrl ? (redirectUrl.hostname || String(redirectUrl)) : "?";
+                    console.error(`Fetch result failed: ${redirectUrl} -> ${execResponse.status} ${execResponse.statusText}${bodyHint}`);
+                    result = new utils.Error("fetching result failed: " + execResponse.status + " from " + host + bodyHint);
                     break;
                 }
             }

--- a/fileserv/routes/module.js
+++ b/fileserv/routes/module.js
@@ -1,4 +1,5 @@
 const { readFile } = require("node:fs/promises");
+const { existsSync } = require("node:fs");
 const express = require("express");
 
 const { ObjectId } = require("mongodb");
@@ -64,8 +65,18 @@ const moduleFilter = (x) => {
  * created module resource. On success it results to the added module's ID.
  */
 const createNewModule = async (metadata, files) => {
+    // Parse functions and exports from multipart JSON strings (API upload sends them as text).
+    const doc = { ...metadata };
+    if (typeof doc.functions === "string") {
+        try { doc.functions = JSON.parse(doc.functions); } catch (_) { /* keep as-is */ }
+    }
+    if (typeof doc.exports === "string") {
+        try { doc.exports = JSON.parse(doc.exports); } catch (_) { doc.exports = []; }
+    }
+    if (!Array.isArray(doc.exports)) doc.exports = doc.exports ? [doc.exports] : [];
+
     // Create the database entry.
-    let moduleId = (await moduleCollection.insertOne(metadata)).insertedId;
+    let moduleId = (await moduleCollection.insertOne(doc)).insertedId;
 
     // Attach the Wasm binary.
     return addModuleBinary({_id: moduleId}, files[0]).then(() => moduleId);
@@ -91,7 +102,7 @@ const describeExistingModule = async (moduleId, descriptionManifest, files) => {
                 .map(([k, v]) => ({ name: k, type: v }));
 
         functions[funcName] = {
-            method: func.method.toLowerCase(),
+            method: (func.method || 'get').toLowerCase(),
             parameters: parameters,
             mounts: "mounts" in func
                 ? Object.fromEntries(
@@ -239,7 +250,7 @@ const getModuleFile = async (request, response) => {
     if (doc) {
         let fileObj;
         if (filename === "wasm") {
-            fileObj = doc.wasm;
+            fileObj = doc.wasm || doc.module;
         } else {
             fileObj = doc.dataFiles[filename];
         }
@@ -250,10 +261,23 @@ const getModuleFile = async (request, response) => {
             });
             return;
         }
-        console.log(`Sending '${filename}' file from file-path: `, fileObj.path);
+        const filePath = fileObj.path;
+        if (!filePath || !existsSync(filePath)) {
+            const hint = filename === "wasm"
+                ? " Re-upload modules with upload_all_modules.py against this orchestrator (ORCHESTRATOR_API_URL)."
+                : "";
+            console.error(`ENOENT: file not found: ${filePath}${hint}`);
+            response.status(404).json({
+                err: `file '${filename}' not found on disk`,
+                path: filePath,
+                hint: hint.trim() || undefined,
+            });
+            return;
+        }
+        console.log(`Sending '${filename}' file from file-path: `, filePath);
         // TODO: A 'datafile' might not be application/binary in every case.
         let options = { headers: { 'Content-Type': filename == "wasm" ? 'application/wasm' : 'application/octet-stream' } };
-        response.sendFile(fileObj.path, options);
+        response.sendFile(filePath, options);
     } else {
         let errmsg = `Failed querying for module id: ${request.params.moduleId}`;
         console.log(errmsg);

--- a/fileserv/src/deviceDiscovery.js
+++ b/fileserv/src/deviceDiscovery.js
@@ -411,16 +411,31 @@ class DeviceManager {
         device["failedHealthCheckCount"] = (device["failedHealthCheckCount"] || 0) + 1;
         console.log('Health check count for device', device.name, 'failed, count:', device["failedHealthCheckCount"]);
 
-        if (device["status"] != "inactive" && DEVICE_HEALTHCHECK_THRESHOLD <= device["failedHealthCheckCount"]) {
-            device["status"] = "inactive";
-            device["statusLog"].unshift({ status: "inactive", time: date });
-            console.log("Device", device.name, "is now inactive");
-            
-            //Checks if the device going to inactive state has been used in active deployments
-            const deviceId = device._id.toString();
-            const inactiveDeviceDeployments = await orchestrator.fetchDeployments(deviceId);
-            if (inactiveDeviceDeployments && inactiveDeviceDeployments.length > 0) {
-                orchestrator.switchToFailovers(inactiveDeviceDeployments, deviceId);
+        const thresholdMet = DEVICE_HEALTHCHECK_THRESHOLD <= device["failedHealthCheckCount"];
+
+        if (thresholdMet) {
+            if (device["status"] !== "inactive") {
+                device["status"] = "inactive";
+                device["statusLog"].unshift({ status: "inactive", time: date });
+                console.log("Device", device.name, "is now inactive");
+
+                const deviceId = device._id.toString();
+                const inactiveDeviceDeployments = await orchestrator.fetchDeployments(deviceId);
+                if (inactiveDeviceDeployments && inactiveDeviceDeployments.length > 0) {
+                    orchestrator.switchToFailovers(inactiveDeviceDeployments, deviceId);
+                }
+            } else {
+                // Device was already inactive (e.g. supervisor down before a deployment was created).
+                // Previously switchToFailovers only ran on the active→inactive transition, so new
+                // deployments that still reference this device as primary never failed over.
+                const deviceId = device._id.toString();
+                const stillReferenced = await orchestrator.fetchDeployments(deviceId);
+                if (stillReferenced && stillReferenced.length > 0) {
+                    console.log(
+                        `Device ${device.name} already inactive — ${stillReferenced.length} deployment(s) still reference it; running failover check`
+                    );
+                    orchestrator.switchToFailovers(stillReferenced, deviceId);
+                }
             }
         }
 

--- a/fileserv/src/orchestrator.js
+++ b/fileserv/src/orchestrator.js
@@ -57,9 +57,10 @@ class MountPathFile {
 
         const mounts = [];
         const encoding = multipartMediaTypeObj.encoding;
+        const toStr = (v) => (typeof v === 'string' ? v : (v && (v.mediaType || v.contentType)) || '');
         for (const [path, _] of getSupportedFileSchemas(schema, encoding)) {
-            const mediaType = encoding[path]['contentType'];
-            // NOTE: The other encoding field ('format') is not regarded here.
+            const raw = encoding[path]['contentType'];
+            const mediaType = toStr(raw) || 'application/octet-stream';
             const mount = new MountPathFile(path, mediaType);
             mounts.push(mount);
         }
@@ -425,6 +426,28 @@ class Orchestrator {
 
         console.log(hydratedManifest.sequence);
 
+        // Hydrate per-step failovers from top-level failoversBySequence when present.
+        // Clients (including the management server) send failover device IDs per step in
+        // failoversBySequence while leaving sequence[i].failovers empty. Previously solve()
+        // only read sequence[i].failovers, so buildFailoverGroup() produced [[primary], ...]
+        // — i.e. each step looked like "failover to self". See docs/ORCHESTRATOR_FAILOVERS_BY_SEQUENCE_FIX.md
+        if (
+            Array.isArray(manifest.failoversBySequence) &&
+            Array.isArray(manifest.sequence) &&
+            manifest.failoversBySequence.length === manifest.sequence.length
+        ) {
+            for (let j = 0; j < manifest.sequence.length; j++) {
+                const row = manifest.failoversBySequence[j];
+                if (!Array.isArray(row) || row.length === 0) {
+                    continue;
+                }
+                const existing = manifest.sequence[j].failovers;
+                if (!Array.isArray(existing) || existing.length === 0) {
+                    manifest.sequence[j].failovers = row;
+                }
+            }
+        }
+
         // Check for blacklisted devices in the manifest sequence (primary devices and failovers)
         for (let step of manifest.sequence) {
             const deviceId = step.device?.toString();
@@ -471,6 +494,9 @@ class Orchestrator {
             // from registry/URL if not found locally.
             // TODO: Actually use a remote-fetch.
             step.module = await this.moduleCollection.findOne(filter);
+            if (!step.module) {
+                throw new Error(`Module not found for sequence step (ID ${(filter._id || filter.name || 'unknown')} may have been deleted). Re-create the deployment.`);
+            }
             // Handle the failovers field in original manifest.
             const failoverDeviceGroup = await this.buildFailoverGroup(manifestStep, availableDevices);
             failoversBySequence.push(failoverDeviceGroup);
@@ -612,8 +638,10 @@ class Orchestrator {
         if (!(["get", "head"].includes(method.toLowerCase()))) {
             // OpenAPI Operation Object's requestBody (including files as input).
             if (request.request_body) {
+                let fileList = files || [];
+                fileList = utils.filterFilesForStartEndpointExecute(deployment, fileList, request);
                 let formData = new FormData();
-                for (let { path, name } of files) {
+                for (let { path, name } of fileList) {
                     formData.append(name, new Blob([fs.readFileSync(path)]));
                 }
                 options.body = formData;
@@ -623,6 +651,10 @@ class Orchestrator {
         }
 
         // Message the first device and return its reaction response.
+        // Use same long Undici timeouts as deploy (default global fetch headersTimeout ~300s).
+        if (constants.deviceFetchAgent) {
+            options.dispatcher = constants.deviceFetchAgent;
+        }
         return fetch(url, options);
     }
 }
@@ -1146,7 +1178,11 @@ function mountsFor(modulee, func, endpoint) {
     }
 
     // Check that all the expected media types are supported.
-    let found_unsupported_medias = request_body_paths.filter(x => !constants.FILE_TYPES.includes(x.media_type));
+    const toMediaTypeStr = (v) => (typeof v === 'string' ? v : (v && v.mediaType) || (v && v.contentType) || String(v || '').split(',')[0] || '');
+    let found_unsupported_medias = request_body_paths.filter(x => {
+        const mt = toMediaTypeStr(x.media_type);
+        return mt && !constants.FILE_TYPES.includes(mt);
+    });
     if (found_unsupported_medias.length > 0) {
         throw new Error(`Input file types not supported: "${found_unsupported_medias}"`);
     }
@@ -1219,6 +1255,9 @@ function fetchAndFindResources(sequence, availableDevices) {
     // Iterate all the items in the request's sequence and fill in the given
     // modules and devices or choose most suitable ones.
     for (let [device, modulee, funcName] of sequence.map(Object.values)) {
+        if (!modulee) {
+            throw `Module not found for sequence step (may have been deleted). Device: ${device && (device._id || device)}`;
+        }
         // If the module and device are orchestrator-based, return immediately.
         if (modulee.isCoreModule) {
             selectedModules.push(modulee);
@@ -1231,17 +1270,35 @@ function fetchAndFindResources(sequence, availableDevices) {
         // always contain the module-id as well.
         // Still, do a validity-check that the requested module indeed
         // contains the func.
-        if (modulee.exports.find(x => x.name === funcName) !== undefined) {
+        let exportsList = modulee.exports;
+        if (typeof exportsList === 'string') {
+            try { exportsList = JSON.parse(exportsList); } catch (_) { exportsList = []; }
+        }
+        if (!Array.isArray(exportsList)) exportsList = [];
+        let funcKnown =
+            exportsList.find(x => x && x.name === funcName) !== undefined;
+        // API-created modules often have `functions` / OpenAPI description but no persisted `exports` array.
+        if (!funcKnown && modulee.functions) {
+            let fnObj = modulee.functions;
+            if (typeof fnObj === 'string') {
+                try { fnObj = JSON.parse(fnObj); } catch (_) { fnObj = null; }
+            }
+            if (fnObj && typeof fnObj === 'object' && Object.prototype.hasOwnProperty.call(fnObj, funcName)) {
+                funcKnown = true;
+            }
+        }
+        if (funcKnown) {
             selectedModules.push(modulee);
         } else {
             throw `Failed to find function '${funcName}' from requested module: ${modulee}`;
         }
 
         function deviceSatisfiesModule(d, m) {
-            return m.requirements.every(
-                r => d.description.supervisorInterfaces.find(
-                    interfacee => interfacee === r.name // i.kind === r.kind && i.module === r.module
-                )
+            const reqs = Array.isArray(m.requirements) ? m.requirements : [];
+            if (reqs.length === 0) return true;
+            const interfaces = (d.description && d.description.supervisorInterfaces) || [];
+            return reqs.every(
+                r => interfaces.find(interfacee => interfacee === (r && r.name))
             );
         }
 

--- a/fileserv/utils.js
+++ b/fileserv/utils.js
@@ -1,11 +1,17 @@
 // Hack to make this file work in both Node.js and browser without erroring.
 let runningInBrowser = false;
 let multer = undefined;
+let deviceFetchAgent = null;
 try {
     multer = require("multer");
 } catch (e) {
     console.log("Importing with 'require' failed; assuming we're in a browser");
     runningInBrowser = true;
+}
+try {
+    deviceFetchAgent = require("./constants.js").deviceFetchAgent;
+} catch (e) {
+    console.warn("Could not load deviceFetchAgent from constants:", e.message);
 }
 
 
@@ -43,7 +49,8 @@ function reducer(dependency, version) {
  * @return {*} Promise of the HTTP response's status code and body parsed from JSON: `{ status, data }`.
  */
 function messageDevice(device, path, body, method="POST") {
-    let url = new URL(`http://${device.communication.addresses[0]}:${device.communication.port}/${path}`);
+    let pathStr = path.startsWith('/') ? path.slice(1) : path;
+    let url = new URL(`http://${device.communication.addresses[0]}:${device.communication.port}/${pathStr}`);
     let requestOptions = {
         method: method,
         headers: {
@@ -54,6 +61,10 @@ function messageDevice(device, path, body, method="POST") {
     };
 
     console.log(`Sending '${method}' request to device '${url}': `, body);
+
+    if (deviceFetchAgent) {
+        requestOptions.dispatcher = deviceFetchAgent;
+    }
 
     return fetch(url, requestOptions)
         .then(response => response.json().then(data => ({ status: response.status, data })));
@@ -115,18 +126,129 @@ const fileUpload =
 function getStartEndpoint(deployment) {
     let startStep = deployment.sequence[0];
     let modId = startStep.module;
+    let devId = startStep.device;
+    if (devId && typeof devId.toString === "function") {
+        devId = devId.toString();
+    }
     let modName = deployment
-        .fullManifest[startStep.device]
+        .fullManifest[devId]
         .modules
         .find(x => x.id.toString() === modId.toString()).name;
     let startEndpoint = deployment
-        .fullManifest[startStep.device]
+        .fullManifest[devId]
         .endpoints[modName][startStep.func];
 
     // Change the string url to an object.
     startEndpoint.url = new URL(startEndpoint.url);
 
     return startEndpoint;
+}
+
+/**
+ * Field names allowed for POST /execute multipart for the **start device**:
+ * union of execution-stage mount names for every sequence step on the same device as
+ * `sequence[0]` (until the sequence leaves that device). The first POST to the supervisor
+ * carries inputs for all chained steps on that host (e.g. distance `input.csv` + LOF
+ * `detect.csv`); dropping non-first-step names used to strip `detect.csv` and break LOF.
+ * Stops at the first step on another device — those steps are not part of this initial POST.
+ * @returns {Set<string>|null} allowed names, or null if manifest cannot be read (caller uses fallback strip)
+ */
+function getAllowedExecutionMultipartFieldNames(deployment) {
+    try {
+        if (!deployment || !deployment.sequence || !deployment.sequence.length || !deployment.fullManifest) {
+            return null;
+        }
+        const startStep = deployment.sequence[0];
+        let startDevId = startStep.device;
+        if (startDevId && typeof startDevId.toString === "function") {
+            startDevId = startDevId.toString();
+        }
+        const node = deployment.fullManifest[startDevId];
+        if (!node || !node.mounts) {
+            return null;
+        }
+        const names = new Set();
+        for (const step of deployment.sequence) {
+            let stepDevId = step.device;
+            if (stepDevId && typeof stepDevId.toString === "function") {
+                stepDevId = stepDevId.toString();
+            }
+            if (stepDevId !== startDevId) {
+                break;
+            }
+            const modId = step.module;
+            const modEntry = (node.modules || []).find(
+                (x) => x && x.id && x.id.toString() === modId.toString()
+            );
+            if (!modEntry || !modEntry.name) {
+                continue;
+            }
+            const modName = modEntry.name;
+            const funcName = step.func;
+            const perFunc = node.mounts[modName] && node.mounts[modName][funcName];
+            if (!perFunc) {
+                continue;
+            }
+            const execArr = perFunc.execution;
+            if (!Array.isArray(execArr)) {
+                continue;
+            }
+            for (const e of execArr) {
+                if (!e) {
+                    continue;
+                }
+                const p = e.path || e.name;
+                if (p) {
+                    names.add(p);
+                }
+            }
+        }
+        return names.size ? names : null;
+    } catch (err) {
+        console.warn("getAllowedExecutionMultipartFieldNames:", err.message);
+        return null;
+    }
+}
+
+/** If manifest is missing, still strip parts that are never valid execute inputs for typical WasmIoT modules. */
+const EXECUTE_MULTIPART_FALLBACK_STRIP = new Set([
+    "output.csv",
+    "trained.bin",
+]);
+
+/**
+ * @param {*} deployment
+ * @param {{ path: string, name: string }[]} files multer file list
+ * @param {*} request start endpoint request (from getStartEndpoint)
+ * @returns {typeof files}
+ */
+function filterFilesForStartEndpointExecute(deployment, files, request) {
+    if (!files || !Array.isArray(files) || files.length === 0) {
+        return files;
+    }
+    if (!request || !request.request_body) {
+        return files;
+    }
+    const allowed = getAllowedExecutionMultipartFieldNames(deployment);
+    if (allowed === null) {
+        const out = files.filter((f) => f && !EXECUTE_MULTIPART_FALLBACK_STRIP.has(f.name));
+        const dropped = files.filter((f) => f && EXECUTE_MULTIPART_FALLBACK_STRIP.has(f.name)).map((f) => f.name);
+        if (dropped.length) {
+            console.log("[execute] Stripped multipart fields (fallback; no execution mount list):", dropped);
+        }
+        return out;
+    }
+    const out = files.filter((f) => f && allowed.has(f.name));
+    const dropped = files.filter((f) => f && !allowed.has(f.name)).map((f) => f.name);
+    if (dropped.length) {
+        console.log(
+            "[execute] Multipart (same-device execution mounts union): dropped:",
+            dropped,
+            "allowed:",
+            [...allowed]
+        );
+    }
+    return out;
 }
 
 /**
@@ -327,6 +449,8 @@ if (!runningInBrowser) {
         validateFileFormSubmission,
         fileUpload,
         getStartEndpoint,
+        getAllowedExecutionMultipartFieldNames,
+        filterFilesForStartEndpointExecute,
         moduleEndpointDescriptions,
         apiCall,
     };


### PR DESCRIPTION
# Orchestrator (`fileserv`) changes for upstream

This note describes edits to the Node orchestrator in [LiquidAI-project/wasmiot-orchestrator](https://github.com/LiquidAI-project/wasmiot-orchestrator), under **`fileserv/`** (API, deployment solving, deploy to supervisors, `POST /execute`). The same repository also contains the [web client](https://github.com/LiquidAI-project/wasmiot-orchestrator/tree/main/client) and other components; this work is limited to the orchestrator service.

These changes were developed in a local copy of upstream. To contribute them: fork the repository on GitHub, push a branch from your fork, and open a pull request against `main` with a short summary of behavior and testing. The sections below are implementation detail you can paste into the PR body or keep as maintainer notes.

---

## What this addresses

Deployment creation, device deploy, and execute misbehave in several situations: modules created through the API (stored shapes differ from GUI-created ones), OpenAPI or manifest fields that are strings or objects instead of what the code assumed, multipart uploads that include fields the first execution step does not accept, slow devices hitting default HTTP timeouts, and failover data sent only at the manifest top level.

---

## Summary

| # | Topic | Symptom / outcome | Where |
|---|--------|-------------------|--------|
| 1 | Exports handling | `modulee.exports.find is not a function` when `exports` is a JSON string or missing | `fileserv/src/orchestrator.js` |
| 2 | Requirements guard | `Cannot read properties of undefined (reading 'every')` when `requirements` is null | `fileserv/src/orchestrator.js` |
| 3 | WASM field fallback | Device gets 404 fetching WASM when API stored the blob under `module` instead of `wasm` | `fileserv/routes/module.js` |
| 4 | Deploy URL path | `POST //deploy` from concatenating `/deploy` with a base URL; some stacks reject the double slash | `fileserv/utils.js` |
| 5 | Mounts + file types | `Input file types not supported` for `text/csv` or when `contentType` is an object | `fileserv/src/orchestrator.js`, `fileserv/constants.js` |
| 6 | HTTP method | 500 on GUI upload when `func.method` is undefined | `fileserv/routes/module.js` |
| 7 | Result URL host | Execute returns 500 “fetching result failed” when supervisor puts `127.0.0.1` in `resultUrl` | `fileserv/routes/execution.js` |
| 8 | Failovers by sequence | Stored failover list only had the primary when clients sent `failoversBySequence` but not per-step `failovers` | `fileserv/src/orchestrator.js` (`solve`) |
| 9 | Long timeouts | `HeadersTimeoutError` on slow `POST /deploy` to a Pi; configurable Undici agent | `fileserv/constants.js`, `utils.js`, `orchestrator.js`, `routes/execution.js`, `package.json` |
| 10 | Health threshold | `DEVICE_HEALTHCHECK_THRESHOLD` was fixed at 5; make it configurable | `fileserv/constants.js` |
| 11 | Failover when already down | `switchToFailovers` only on active→inactive; deployments created while primary was already offline did not switch | `fileserv/src/deviceDiscovery.js` |
| 12 | Execute multipart + manifest key | Strip non–execution-stage parts; index `fullManifest` with `device.toString()` for ObjectId keys | `fileserv/utils.js`, `fileserv/src/orchestrator.js` (`schedule`) |
| 13 | Result vs request-history | Immediate JSON shows a mount-like error string while request-history says success; prefer history when consistent | `fileserv/routes/execution.js` |

Items 3 and 4 affect whether devices can pull WASM and complete deploy. Items 1, 2, and 5 affect manifest construction. Items 7 and 12–13 affect `/execute` with real supervisors and clients.

---

## Operational notes (not fixed by code alone)

These show up in integration tests; correcting data and deployment flow still matters.

### A. `Deployment validation failed` / `Module card not found for module …`

`validateDeploymentSolution` reads `modulecards` in MongoDB. If the module exists but no module card matches that module id, validation marks that step invalid.

### B. `ENOENT` on `GET /file/module/…/wasm`

The module document references a path under `files/wasm/`. If the file was never uploaded to this orchestrator or the volume was cleared, deploy fails even though Mongo still has a row. Re-upload artifacts to the orchestrator instance devices use.

### C. `Deployment not found` on `POST /execute/:id`

No deployment document for that id. Often: `solve()` failed earlier but the client kept an old id; wrong database; or deploy never completed so nothing usable was activated. Check `GET /file/manifest/:id` and that solve finished without validation errors before calling `/execute`.

### D. Health check failures for `device 'orchestrator'`

The orchestrator may register itself with an internal Docker address. Health checks to that address can fail while edge devices are fine. Usually log noise, not the root cause of Pi deploy failures.

### E. `failoverValidator` / same device skipped

If a failover id duplicates the primary, the validator may skip it, which can be expected.

---

## Multi-step execute and merged deployments

For several WASM steps on one device, execute uses multipart toward the supervisor. `POST /execute/{deploymentId}` always starts at `sequence[0]`. What matters is how the supervisor applies that multipart to the first module.

**Single merged deployment:** One manifest lists all steps; the client sent every step’s files in one multipart body. The supervisor forwards the full set to the first step only, so later-step files are rejected as unexpected mounts.

**One deployment per task:** Avoids many multipart mismatches per step at the cost of more deploy churn and weaker single-run visibility across devices.

**One deployment per device:** Groups steps in one manifest; deploy improves, but `/execute` still sends one multipart to step 0 unless attachments are limited to that step or the supervisor filters per module.

**Current external integration:** Multipart via the orchestrator includes only mounts for `sequence[0]`; later steps are invoked separately against the supervisor with per-step files; results merged (e.g. `PIPELINE_ORCHESTRATOR_DIRECT_FOLLOWUP_TAIL`, default true).

**Failover gap:** Orchestrator failover applies to the first `/execute` step. Later steps that call the supervisor directly use the primary from the registry and do not automatically follow the same failover selection. Extending that needs design and tests.

---

## Implementation: exports handling

**File:** `fileserv/src/orchestrator.js` — `fetchAndFindResources`, function validation.

Replace:

```javascript
if (modulee.exports.find(x => x.name === funcName) !== undefined) {
```

With:

```javascript
let exportsList = modulee.exports;
if (typeof exportsList === 'string') {
    try { exportsList = JSON.parse(exportsList); } catch (_) { exportsList = []; }
}
if (!Array.isArray(exportsList)) exportsList = [];
if (exportsList.find(x => x && x.name === funcName) !== undefined) {
```

---

## Implementation: requirements guard

**File:** `fileserv/src/orchestrator.js` — `deviceSatisfiesModule` inside `fetchAndFindResources`.

Replace:

```javascript
function deviceSatisfiesModule(d, m) {
    return m.requirements.every(
        r => d.description.supervisorInterfaces.find(
            interfacee => interfacee === r.name // i.kind === r.kind && i.module === r.module
        )
    );
}
```

With:

```javascript
function deviceSatisfiesModule(d, m) {
    const reqs = Array.isArray(m.requirements) ? m.requirements : [];
    if (reqs.length === 0) return true;
    const interfaces = (d.description && d.description.supervisorInterfaces) || [];
    return reqs.every(
        r => interfaces.find(interfacee => interfacee === (r && r.name))
    );
}
```

---

## Implementation: WASM served from `module` when `wasm` is absent

**File:** `fileserv/routes/module.js` — `getModuleFile`, WASM branch.

Replace:

```javascript
if (filename === "wasm") {
    fileObj = doc.wasm;
} else {
```

With:

```javascript
if (filename === "wasm") {
    fileObj = doc.wasm || doc.module;
} else {
```

API-created modules may store the binary under `module`. Devices request `/file/module/:id/wasm`; without the fallback they can get 400 and deploy fails.

---

## Implementation: avoid `//` in device request URLs

**File:** `fileserv/utils.js` — `messageDevice`.

Replace:

```javascript
function messageDevice(device, path, body, method="POST") {
    let url = new URL(`http://${device.communication.addresses[0]}:${device.communication.port}/${path}`);
```

With:

```javascript
function messageDevice(device, path, body, method="POST") {
    let pathStr = path.startsWith('/') ? path.slice(1) : path;
    let url = new URL(`http://${device.communication.addresses[0]}:${device.communication.port}/${pathStr}`);
```

If `path` is `"/deploy"`, naive concatenation can produce `//deploy`; not all HTTP stacks accept that.

---

## Implementation: mountsFor mediaType normalization

**File:** `fileserv/src/orchestrator.js` — `MountPathFile.listFromMultipart`.

Replace:

```javascript
for (const [path, _] of getSupportedFileSchemas(schema, encoding)) {
    const mediaType = encoding[path]['contentType'];
    // NOTE: The other encoding field ('format') is not regarded here.
    const mount = new MountPathFile(path, mediaType);
    mounts.push(mount);
}
```

With:

```javascript
const toStr = (v) => (typeof v === 'string' ? v : (v && (v.mediaType || v.contentType)) || '');
for (const [path, _] of getSupportedFileSchemas(schema, encoding)) {
    const raw = encoding[path]['contentType'];
    const mediaType = toStr(raw) || 'application/octet-stream';
    const mount = new MountPathFile(path, mediaType);
    mounts.push(mount);
}
```

---

## Implementation: FILE_TYPES check and `text/csv`

**File:** `fileserv/src/orchestrator.js` — `mountsFor`, FILE_TYPES filter.

Replace:

```javascript
let found_unsupported_medias = request_body_paths.filter(x => !constants.FILE_TYPES.includes(x.media_type));
```

With:

```javascript
const toMediaTypeStr = (v) => (typeof v === 'string' ? v : (v && v.mediaType) || (v && v.contentType) || String(v || '').split(',')[0] || '');
let found_unsupported_medias = request_body_paths.filter(x => {
    const mt = toMediaTypeStr(x.media_type);
    return mt && !constants.FILE_TYPES.includes(mt);
});
```

**File:** `fileserv/constants.js` — extend the allowlist:

```javascript
const FILE_TYPES = [
    "image/png",
    "image/jpeg",
    "image/jpg",
    "application/octet-stream",
    "text/csv"
];
```

---

## Implementation: safe default for HTTP method

**File:** `fileserv/routes/module.js` — `describeExistingModule`.

Replace `method: func.method.toLowerCase()` with:

```javascript
method: (func.method || 'get').toLowerCase(),
```

---

## Implementation: rewrite `resultUrl` localhost to the device host

**File:** `fileserv/routes/execution.js`

Supervisors sometimes return `resultUrl` with `127.0.0.1` or `localhost`. If the orchestrator runs elsewhere, fetching that URL fails and surfaces as 500 (“fetching result failed”).

Add `rewriteResultUrl(url, deviceHost)` to replace loopback hosts with the supervisor’s reachable address. Use it before `fetch(redirectUrl)` when following `resultUrl`, and when returning `resultUrl` to the client. Derive `deviceHost` from `utils.getStartEndpoint(deployment).url.hostname`.

---

## Implementation: hydrate `failoversBySequence` into `sequence[].failovers`

**File:** `fileserv/src/orchestrator.js` — start of `solve()`, after cloning the manifest and before the blacklist loop.

`buildFailoverGroup()` reads `manifest.sequence[i].failovers`. Some clients only send top-level `failoversBySequence`. If that array exists, matches `sequence` length, and a step has no `failovers` yet, copy `failoversBySequence[j]` into `manifest.sequence[j].failovers`. Non-empty per-step `failovers` wins over the top-level copy.

---

## Implementation: Undici timeouts for orchestrator → device

Node’s `fetch()` uses Undici; default header timeouts can be too short for slow `POST /deploy` on constrained hardware, leading to `HeadersTimeoutError` and 500 responses.

Add the `undici` dependency. In `fileserv/constants.js`, expose a shared `Agent` with `ORCH_DEVICE_HEADERS_TIMEOUT_MS`, `ORCH_DEVICE_BODY_TIMEOUT_MS`, and `ORCH_DEVICE_CONNECT_TIMEOUT_MS` (for example 900000 ms defaults). Pass `dispatcher: deviceFetchAgent` from `messageDevice` (`utils.js`), `schedule()`’s device `fetch` (`orchestrator.js`), and result polling (`execution.js`). Pin `undici` in `fileserv/package.json` or the repo root per upstream layout.

---

## Implementation: configurable `DEVICE_HEALTHCHECK_THRESHOLD`

**File:** `fileserv/constants.js`

Replace a literal `DEVICE_HEALTHCHECK_THRESHOLD: 5` with:

```javascript
DEVICE_HEALTHCHECK_THRESHOLD: parseInt(process.env.DEVICE_HEALTHCHECK_THRESHOLD || "5", 10),
```

Default `"5"` keeps current behavior; adjust in environment for faster lab failover or stricter production policy.

---

## Implementation: call `switchToFailovers` when already inactive

**File:** `fileserv/src/deviceDiscovery.js` — `unsuccessfulHealthCheck`

Previously `switchToFailovers` ran mainly on transition to inactive. If the device was already inactive, new deployments could still list it in `sequence` without triggering another transition, so failovers never updated. When failed health checks meet the threshold and the device is already inactive, still load deployments and run `switchToFailovers` if any deployment’s `sequence` references that device. After sequences update, later calls become no-ops.

---

## Implementation: execute multipart filtering and `fullManifest` lookup

**Files:** `fileserv/utils.js`, `fileserv/src/orchestrator.js`

For `POST /execute`, forwarded multipart must match execution-stage mounts for the first step. Merged OpenAPI schemas may list output names; clients may attach files only valid for later steps. Use `mounts[module][func].execution` to allow only those paths; drop other parts. If the manifest is incomplete, a conservative strip (e.g. `output.csv`, `trained.bin`) can help.

`deployment.fullManifest` keys are strings; use `startStep.device.toString()` when indexing so ObjectId-valued devices match.

Sketch: `getAllowedExecutionMultipartFieldNames(deployment)`, `filterFilesForStartEndpointExecute(deployment, files, request)`; update `getStartEndpoint`; in `schedule()`, filter the file list before building `FormData`.

---

## Implementation: prefer request-history when immediate `result` looks like a mount error

**File:** `fileserv/routes/execution.js`

If the JSON body has a mount-like string in `result` but `resultUrl` points at request-history with `success: true`, GET the rewritten URL (same host fix as above) and, when appropriate, return that success to the API client.

---

## Optional: `MONGO_URI` and unauthenticated MongoDB

**File:** `fileserv/constants.js`

When `MONGO_USER` / `MONGO_PASS` are unset, avoid building `mongodb://undefined:undefined@...`. Prefer `process.env.MONGO_URI` or fall back to `mongodb://${MONGO_HOST}:${MONGO_PORT}/` without credentials when no user/password are set.

---

## Docker image

From the repository root that contains the `fileserv` Dockerfile:

```bash
docker build -t wasmiot-orchestrator:local .
```

Configure timeouts and health checks to match your network and devices:

| Variable | Purpose |
|----------|---------|
| `ORCH_DEVICE_HEADERS_TIMEOUT_MS` | Undici headers timeout (if you raise defaults, document the value in the PR) |
| `ORCH_DEVICE_BODY_TIMEOUT_MS` | Response body timeout |
| `ORCH_DEVICE_CONNECT_TIMEOUT_MS` | TCP connect timeout |
| `DEVICE_HEALTHCHECK_THRESHOLD` | Failed checks before marking device inactive (default 5) |
| `EXECUTION_RESULT_FETCH_TIMEOUT_MS` | Polling timeout for `/execute` result handling |
